### PR TITLE
Added Support for FTPS

### DIFF
--- a/src/main/java/org/onedatashare/transferservice/odstransferservice/model/credential/AccountEndpointCredential.java
+++ b/src/main/java/org/onedatashare/transferservice/odstransferservice/model/credential/AccountEndpointCredential.java
@@ -2,6 +2,7 @@ package org.onedatashare.transferservice.odstransferservice.model.credential;
 
 import lombok.Data;
 import lombok.ToString;
+import org.apache.commons.lang.StringUtils;
 import org.onedatashare.transferservice.odstransferservice.Enum.EndpointType;
 
 @Data
@@ -17,7 +18,9 @@ public class AccountEndpointCredential extends EndpointCredential{
         if(type.equals(EndpointType.sftp)){
             noTypeUri = credential.getUri().replaceFirst("sftp://", "");
         }else if(type.equals(EndpointType.ftp)){
-            noTypeUri = credential.getUri().replaceFirst("ftp://", "");
+            noTypeUri = credential.getUri().startsWith("ftps://") ?
+                    credential.getUri().replaceFirst("ftps://", "")
+                   : credential.getUri().replaceFirst("ftp://", "");
         }
         else{
             noTypeUri = credential.getUri().replaceFirst("http://", "");


### PR DESCRIPTION
Before Transfer

Target Location  
![image](https://github.com/didclab/Transfer-Service/assets/21127827/fad867c9-f9c2-43e0-86a1-8ebf1cca9a95)

Post man request to transfer data from ftps server to local machine
![image](https://github.com/didclab/Transfer-Service/assets/21127827/6e7ca4bb-5228-450e-962e-f09ae2822c35)

Logs Processing Request
![image](https://github.com/didclab/Transfer-Service/assets/21127827/5ddac7cf-7600-4c72-9147-e3a3fa440c6e)


After Transfer
![image](https://github.com/didclab/Transfer-Service/assets/21127827/e8550de2-061d-441c-a4e0-eb2e8c92d739)


Note:
The changes are for FTPS over explicit connection.
We will need to test FTPS over implicit connection. Implicit connection are outdated/obsolute nowdays so kind of less impact